### PR TITLE
Improved the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
+sudo: false
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "pypy"
 env:
-    - DJANGO='django>=1.4,<1.5'
-    - DJANGO='django>=1.5'
+    - DJANGO='Django>=1.4,<1.5'
+    - DJANGO='Django>=1.5,<1.6'
+    - DJANGO='Django>=1.6,<1.7'
+    - DJANGO='Django>=1.7,<1.8'
 install:
-  - pip install $DJANGO --use-mirrors
+  - travis_retry pip install $DJANGO
 # command to run tests
 script: python manage.py test absolute


### PR DESCRIPTION
I added more django versions and more python versions to test against, moved the build to the new docker based build worker and replaced --use-mirrors with travis_retry because --use-mirrors is deprecated.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/noirbizarre/django-absolute/7)

<!-- Reviewable:end -->
